### PR TITLE
Optimize AudioSegment.fade

### DIFF
--- a/API.markdown
+++ b/API.markdown
@@ -415,7 +415,7 @@ fade_quieter_beteen_2_and_3_seconds = sound1.fade(to_gain=-3.5, start=2000, end=
 
 # easy way is to use the .fade_in() convenience method. note: -120dB is basically silent.
 fade_in_the_hard_way = sound1.fade(from_gain=-120.0, start=0, duration=5000)
-fade_out_the_hard_way = sound1.fade(to_gain=-120.0, end=0, duration=5000)
+fade_out_the_hard_way = sound1.fade(to_gain=-120.0, end=float('inf'), duration=5000)
 ```
 
 **Supported keyword arguments**:

--- a/AUTHORS
+++ b/AUTHORS
@@ -63,3 +63,6 @@ Mike Mattozzi
 
 Marcio Mazza
     github: marciomazza
+
+Sungsu Lim
+    github: proflim

--- a/AUTHORS
+++ b/AUTHORS
@@ -66,3 +66,6 @@ Marcio Mazza
 
 Sungsu Lim
     github: proflim
+
+Xuyuan Chen
+    github: crouchred

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -1010,6 +1010,8 @@ class AudioSegment(object):
             elif end is not None:
                 start = end - duration
         else:
+            start = 0 if start is None else start
+            end = len(self) if end is None else end
             duration = end - start
 
         from_power = db_to_float(from_gain)

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -508,12 +508,13 @@ class AudioSegment(object):
         if p.returncode != 0:
             raise CouldntDecodeError("Decoding failed. ffmpeg returned error code: {0}\n\nOutput from ffmpeg/avlib:\n\n{1}".format(p.returncode, p_err))
 
-        obj = cls._from_safe_wav(output)
-
-        input_file.close()
-        output.close()
-        os.unlink(input_file.name)
-        os.unlink(output.name)
+        try:
+          obj = cls._from_safe_wav(output)
+        finally:
+          input_file.close()
+          output.close()
+          os.unlink(input_file.name)
+          os.unlink(output.name)
 
         return obj
 

--- a/pydub/silence.py
+++ b/pydub/silence.py
@@ -1,3 +1,5 @@
+import itertools
+
 from .utils import db_to_float
 
 
@@ -16,13 +18,13 @@ def detect_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, seek
 
     # check successive (1 sec by default) chunk of sound for silence
     # try a chunk at every "seek step" (or every chunk for a seek step == 1)
-    #
-    # make sure the last portion of the audio is included in the seach
-    # even when seek step is greater than 1
     last_slice_start = seg_len - min_silence_len
     slice_starts = range(0, last_slice_start + 1, seek_step)
-    if slice_starts[-1] != last_slice_start:
-        slice_starts.append(last_slice_start)
+
+    # guarantee last_slice_start is included in the range
+    # to make sure the last portion of the audio is seached
+    if last_slice_start % seek_step:
+        slice_starts = itertools.chain(slice_starts, [last_slice_start])
 
     for i in slice_starts:
         audio_slice = audio_segment[i:i + min_silence_len]

--- a/pydub/silence.py
+++ b/pydub/silence.py
@@ -1,9 +1,7 @@
-from .utils import (
-    db_to_float,
-)
+from .utils import db_to_float
 
 
-def detect_silence(audio_segment, min_silence_len=1000, silence_thresh=-16):
+def detect_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, seek_step=1):
     seg_len = len(audio_segment)
 
     # you can't have a silent portion of a sound that is longer than the sound
@@ -16,11 +14,18 @@ def detect_silence(audio_segment, min_silence_len=1000, silence_thresh=-16):
     # find silence and add start and end indicies to the to_cut list
     silence_starts = []
 
-    # check every (1 sec by default) chunk of sound for silence
-    slice_starts = seg_len - min_silence_len
+    # check successive (1 sec by default) chunk of sound for silence
+    # try a chunk at every "seek step" (or every chunk for a seek step == 1)
+    #
+    # make sure the last portion of the audio is included in the seach
+    # even when seek step is greater than 1
+    last_slice_start = seg_len - min_silence_len
+    slice_starts = range(0, last_slice_start + 1, seek_step)
+    if slice_starts[-1] != last_slice_start:
+        slice_starts.append(last_slice_start)
 
-    for i in range(slice_starts + 1):
-        audio_slice = audio_segment[i:i+min_silence_len]
+    for i in slice_starts:
+        audio_slice = audio_segment[i:i + min_silence_len]
         if audio_slice.rms < silence_thresh:
             silence_starts.append(i)
 
@@ -54,8 +59,8 @@ def detect_silence(audio_segment, min_silence_len=1000, silence_thresh=-16):
     return silent_ranges
 
 
-def detect_nonsilent(audio_segment, min_silence_len=1000, silence_thresh=-16):
-    silent_ranges = detect_silence(audio_segment, min_silence_len, silence_thresh)
+def detect_nonsilent(audio_segment, min_silence_len=1000, silence_thresh=-16, seek_step=1):
+    silent_ranges = detect_silence(audio_segment, min_silence_len, silence_thresh, seek_step)
     len_seg = len(audio_segment)
 
     # if there is no silence, the whole thing is nonsilent
@@ -81,8 +86,8 @@ def detect_nonsilent(audio_segment, min_silence_len=1000, silence_thresh=-16):
     return nonsilent_ranges
 
 
-
-def split_on_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, keep_silence=100):
+def split_on_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, keep_silence=100,
+                     seek_step=1):
     """
     audio_segment - original pydub.AudioSegment() object
 
@@ -97,7 +102,7 @@ def split_on_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, ke
         abruptly cut off. (default: 100ms)
     """
 
-    not_silence_ranges = detect_nonsilent(audio_segment, min_silence_len, silence_thresh)
+    not_silence_ranges = detect_nonsilent(audio_segment, min_silence_len, silence_thresh, seek_step)
 
     chunks = []
     for start_i, end_i in not_silence_ranges:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal = 1
+
+[pep8]
+max-line-length = 100

--- a/test/test.py
+++ b/test/test.py
@@ -868,6 +868,11 @@ class SilenceTests(unittest.TestCase):
         silent_ranges = detect_silence(self.seg1, min_silence_len=500, silence_thresh=-20)
         self.assertEqual(silent_ranges, [[0, 775], [3141, 4033], [5516, 6051]])
 
+    def test_detect_silence_seg1_with_seek_split(self):
+        silent_ranges = detect_silence(self.seg1, min_silence_len=500, silence_thresh=-20,
+                                       seek_step=10)
+        self.assertEqual(silent_ranges, [[0, 770], [3150, 4030], [5520, 6050]])
+
     def test_realistic_audio(self):
         silent_ranges = detect_silence(self.seg4, min_silence_len=1000, silence_thresh=self.seg4.dBFS)
 


### PR DESCRIPTION
In AudioSegment.fade
Since the 'start' and 'end' params default to be the beginning and the end of this segment, It should still work even none of [start, end, duration] is set. 
But It will confusing if only duration is set, so throw an error.
What 's more, it's a little confusing about the `fade_out_the_hard_way` if end=0 in API.markdown